### PR TITLE
Fix compilation error with commit 75ce09ac4af7 of pandoc-diagrams

### DIFF
--- a/src/Hakyll/Web/Diagrams.hs
+++ b/src/Hakyll/Web/Diagrams.hs
@@ -46,4 +46,10 @@ diagramsTransformer outDir pandoc = unsafeCompiler $ renderBlockDiagrams outDir 
 --   from the output) and provided as additional definitions that will
 --   be in scope during evaluation of all @diagrams@ blocks.
 renderBlockDiagrams :: FilePath -> Pandoc -> IO Pandoc
-renderBlockDiagrams outDir p = bottomUpM (insertDiagrams $ Opts outDir "example") p
+renderBlockDiagrams outDir p = bottomUpM (concatMapM (diagramsFilter outDir)) p
+
+diagramsFilter :: FilePath -> Block -> IO [Block]
+diagramsFilter outDir x = (insertDiagrams $ Opts "html" outDir "example") x
+
+concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
+concatMapM f xs = concat <$> mapM f xs


### PR DESCRIPTION
Hi,

This commit fixes compilation error against the latest version of diagrams-pandoc. Please review and merge. Please let me know if the compilation error is unexpected or a change is needed in the commit below.

Thanks and Regards,
Venkat
